### PR TITLE
Changed order of text display to run mix ecto.create before mix phoen…

### DIFF
--- a/installer/lib/mix/tasks/phoenix.new.ex
+++ b/installer/lib/mix/tasks/phoenix.new.ex
@@ -248,11 +248,11 @@ defmodule Mix.Tasks.Phoenix.New do
       brunch? = install_brunch(install?)
       extra   = if mix?, do: [], else: ["$ mix deps.get"]
 
-      print_mix_info(path, extra)
-
       if binding[:ecto] do
         print_ecto_info()
       end
+
+      print_mix_info(path, extra)
 
       if not brunch? do
         print_brunch_info()


### PR DESCRIPTION
Changed order of text display to run mix ecto.create before running mix phoenix.server.  The mix ecto.create is required before running mix phoenix.server but the text currently is in the opposite order. 